### PR TITLE
feat: add manual date selection and date-based grouping

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -33,9 +33,8 @@ const onChange = (event, selectedDate) => {
 };
 ```
 
-### 5. Check for Library Issues
-- Ensure `@react-native-community/datetimepicker` is correctly installed in `package.json`.
-- If you just installed it, you may need to restart the Expo development server (`npx expo start -c`).
-
-## Note for Agent
-Follow these steps in order. Start by logging the state change to the console to confirm the `onPress` is actually triggering the state update.
+### 6. Special Case: Invisible Picker inside a Modal
+If the Modal shows up (you see the "Done" button) but the picker is missing:
+- **Change Display Mode**: Remove `display="spinner"` and use `display="default"`. Spinner mode often requires very specific parent container heights to be visible.
+- **Background Color**: On some versions of Android/iOS, if the theme is dark but the picker doesn't detect it, it might render white text on a white background. Try setting an explicit `textColor` prop if available, or check if the parent `View` background is conflicting.
+- **Direct Rendering**: On Android, try rendering the `<DateTimePicker>` *outside* of the `<Modal>` component. The library's `default` mode on Android creates its own native modal, and nesting it inside a React Native `<Modal>` can cause z-index or visibility issues.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,41 @@
+# Troubleshooting Guide: Fixing Date Picker Visibility
+
+## Issue
+When clicking the date selection button, the button flashes (indicating a press) but the date picker modal does not appear.
+
+## Step-by-Step Fix Instructions
+
+### 1. Verify State Management
+Ensure you have a boolean state to control the visibility of the picker.
+- **Check**: Is `setShowPicker(true)` being called in the button's `onPress`?
+- **Check**: Is the picker component only rendered conditionally (e.g., `{showPicker && <DateTimePicker ... />}`)?
+
+### 2. Platform-Specific Behavior (Android vs. iOS)
+If you are using `@react-native-community/datetimepicker`:
+- **Android**: The picker is a separate modal. When the user selects a date or cancels, you **must** set the `showPicker` state back to `false` in the `onChange` callback. If you don't, the component might "think" it's already open and won't show again on the next click.
+- **iOS**: The picker can be `inline`, `spinner`, or `compact`. If using `inline`, it doesn't need a modal but should be placed correctly in the view hierarchy.
+
+### 3. Proper Placement in the Component Tree
+- Ensure the `<DateTimePicker>` component is NOT nested inside a restricted view (like one with `overflow: 'hidden'`).
+- Try placing the picker component at the very bottom of your screen's main `<View>`, just before the closing tag.
+
+### 4. Correct Event Handling
+Your `onChange` function should handle both the "set" and "dismissed" actions:
+```javascript
+const onChange = (event, selectedDate) => {
+  // 1. Immediately hide the picker (especially important for Android)
+  setShowPicker(false);
+  
+  if (selectedDate) {
+    // 2. Update your date state
+    setDate(selectedDate);
+  }
+};
+```
+
+### 5. Check for Library Issues
+- Ensure `@react-native-community/datetimepicker` is correctly installed in `package.json`.
+- If you just installed it, you may need to restart the Expo development server (`npx expo start -c`).
+
+## Note for Agent
+Follow these steps in order. Start by logging the state change to the console to confirm the `onPress` is actually triggering the state update.

--- a/app.json
+++ b/app.json
@@ -3,6 +3,9 @@
     "name": "expo-expense-tracker",
     "slug": "expo-expense-tracker",
     "version": "1.0.0",
-    "userInterfaceStyle": "automatic"
+    "userInterfaceStyle": "automatic",
+    "plugins": [
+      "@react-native-community/datetimepicker"
+    ]
   }
 }

--- a/issue.md
+++ b/issue.md
@@ -1,18 +1,18 @@
-# Issue: Redesign "Add Expense" Button to Floating Action Button (FAB)
+# Issue: Manual Date Selection and Date-based Grouping
 
 ## Overview
-The current "Add Expense" button is a full-width button located below the dashboard, which takes up significant vertical space. We want to move to a more modern "Floating Action Button" (FAB) pattern.
+Currently, expenses are automatically assigned the creation date, making it impossible to log past or future transactions. Additionally, the main expense list is a flat list that becomes difficult to read as it grows.
 
 ## Goals
-- **UI Change**: Replace the existing full-width "Add Expense" button with a circular button.
-- **Positioning**: The new button should be fixed to the bottom right corner of the Home screen.
-- **Iconography**: Use a "+" (plus) icon inside the circular button.
-- **Visuals**: Ensure the button has a distinct background color (e.g., the primary theme color) and a subtle shadow to make it appear "floating."
+- **Manual Date Entry**: Add a date picker or input field to both the "Add Expense" and "Edit Expense" screens.
+- **Data Model**: Ensure the user-selected date is saved in the expense record.
+- **Organized View**: Group the expenses on the Home screen by their date (e.g., "Today", "Yesterday", or "April 7, 2026").
+- **Sorting**: Ensure expenses within each group are sorted chronologically (or reverse-chronologically).
 
 ## Technical Guidance
-- **Styling**: Use **NativeWind** (Tailwind CSS) for positioning (`absolute`, `bottom-8`, `right-8`).
-- **Icons**: Use `Ionicons` (already used in the project) for the plus icon.
-- **Component**: Ensure the button remains accessible and has a proper hit area.
+- **Picker**: Use a standard React Native / Expo date picker library.
+- **UI Logic**: Consider switching the `FlatList` on the Home screen to a `SectionList` to handle the grouped data structure more effectively.
+- **Formatting**: Use a consistent date format for the group headers.
 
 ## Note for Developer
-The button should stay in place even when the expense list is scrolled. Think about the z-index and how it interacts with the list items behind it. Feel free to add a slight elevation or shadow to make it pop.
+The goal is to give users more control over their financial history. The grouping should make the dashboard feel organized and easy to scan. Think about how to handle empty states or very long lists within a single date group.

--- a/issue.md
+++ b/issue.md
@@ -1,18 +1,20 @@
-# Issue: Manual Date Selection and Date-based Grouping
+# Issue: Fix Invisible Date Picker
 
 ## Overview
-Currently, expenses are automatically assigned the creation date, making it impossible to log past or future transactions. Additionally, the main expense list is a flat list that becomes difficult to read as it grows.
+The current implementation of the date picker shows the modal container and the header (Cancel/Done buttons), but the actual calendar or spinner is invisible to the user.
+
+## The Problem
+Using `display="spinner"` inside a `Modal` often leads to layout issues where the picker has zero height or is rendered outside the visible area, especially when specific `style` properties are missing or conflicting with the modal's container.
 
 ## Goals
-- **Manual Date Entry**: Add a date picker or input field to both the "Add Expense" and "Edit Expense" screens.
-- **Data Model**: Ensure the user-selected date is saved in the expense record.
-- **Organized View**: Group the expenses on the Home screen by their date (e.g., "Today", "Yesterday", or "April 7, 2026").
-- **Sorting**: Ensure expenses within each group are sorted chronologically (or reverse-chronologically).
+- **Fix Visibility**: Ensure the date picker is fully visible when the modal opens.
+- **Platform Defaults**: Change the picker to use the system default display mode (`default`) for better reliability.
+- **Layout**: Ensure the picker occupies the correct space within the modal.
 
 ## Technical Guidance
-- **Picker**: Use a standard React Native / Expo date picker library.
-- **UI Logic**: Consider switching the `FlatList` on the Home screen to a `SectionList` to handle the grouped data structure more effectively.
-- **Formatting**: Use a consistent date format for the group headers.
+- **Display Mode**: Change `display="spinner"` to `display="default"` (or remove the prop to use the default).
+- **Styling**: On iOS, if you must use `spinner`, ensure the `DateTimePicker` has an explicit `width` and `height` that fits within the parent `View`.
+- **Simplification**: Consider if a `Modal` is strictly necessary on Android, as the library already provides a native modal dialog for that platform.
 
 ## Note for Developer
-The goal is to give users more control over their financial history. The grouping should make the dashboard feel organized and easy to scan. Think about how to handle empty states or very long lists within a single date group.
+Test this on both iOS and Android if possible. The `default` display mode is generally the most robust and matches user expectations for each platform.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@react-native-community/datetimepicker": "8.6.0",
         "@react-navigation/native": "^7.2.2",
         "@react-navigation/native-stack": "^7.14.10",
         "expo": "^55.0.9",
@@ -2247,6 +2248,29 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.6.0.tgz",
+      "integrity": "sha512-yxPSqNfxgpGaqHQIpatqe6ykeBdU/1pdsk/G3x01mY2bpTflLpmVTLqFSJYd3MiZzxNZcMs/j1dQakUczSjcYA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/titanaprilian/expo-expense-tracker#readme",
   "dependencies": {
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/datetimepicker": "8.6.0",
     "@react-navigation/native": "^7.2.2",
     "@react-navigation/native-stack": "^7.14.10",
     "expo": "^55.0.9",

--- a/src/features/expense/hooks/useAddExpense.ts
+++ b/src/features/expense/hooks/useAddExpense.ts
@@ -14,6 +14,7 @@ export const useAddExpense = (navigation: AddExpenseScreenProps['navigation']) =
   const [amount, setAmount] = useState('');
   const [category, setCategory] = useState('');
   const [note, setNote] = useState('');
+  const [date, setDate] = useState(new Date());
   const addExpense = useExpenseStore((state) => state.addExpense);
 
   const handleAmountChange = (value: string) => {
@@ -38,7 +39,7 @@ export const useAddExpense = (navigation: AddExpenseScreenProps['navigation']) =
       amount: numericAmount,
       category,
       note: note || '',
-      date: new Date().toISOString(),
+      date: date.toISOString(),
     };
 
     addExpense(expense);
@@ -52,6 +53,8 @@ export const useAddExpense = (navigation: AddExpenseScreenProps['navigation']) =
     setCategory,
     note,
     setNote,
+    date,
+    setDate,
     handleSave,
   };
 };

--- a/src/screens/AddExpenseScreen.tsx
+++ b/src/screens/AddExpenseScreen.tsx
@@ -1,4 +1,4 @@
-import { Text, View, TextInput, TouchableOpacity, ColorSchemeName, Modal } from 'react-native';
+import { Text, View, TextInput, TouchableOpacity, ColorSchemeName, Modal, Platform } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../navigation/AppNavigator';
@@ -8,6 +8,7 @@ import { COLORS } from '../constants/colors';
 import { AnimatedButton } from '../components/AnimatedButton';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import { useState } from 'react';
+import DateTimePicker from '@react-native-community/datetimepicker';
 
 type AddExpenseScreenProps = {
   navigation: NativeStackNavigationProp<RootStackParamList, 'AddExpense'>;
@@ -142,8 +143,9 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Date</Text>
       <TouchableOpacity
         onPress={() => {
-          console.log('Date button pressed, setting showDatePicker to true');
-          setShowDatePicker(true);
+          if (Platform.OS === 'ios') {
+            setShowDatePicker(true);
+          }
         }}
         style={{
           borderWidth: 1,
@@ -161,87 +163,39 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
         <Ionicons name="calendar-outline" size={20} color={textSecondary} />
       </TouchableOpacity>
 
-      {showDatePicker && (
-        <Modal
-          visible={true}
-          transparent={true}
-          animationType="fade"
-          onRequestClose={() => setShowDatePicker(false)}
-        >
+      {Platform.OS === 'android' && (
+        <DateTimePicker
+          value={date}
+          mode="date"
+          display="default"
+          onChange={(event, selectedDate) => {
+            if (selectedDate) {
+              setDate(selectedDate);
+            }
+          }}
+        />
+      )}
+
+      {showDatePicker && Platform.OS === 'ios' && (
+        <View style={{ height: 300, marginBottom: 20 }}>
+          <DateTimePicker
+            value={date}
+            mode="date"
+            display="spinner"
+            onChange={(event, selectedDate) => {
+              if (selectedDate) {
+                setDate(selectedDate);
+              }
+            }}
+            style={{ backgroundColor: surfaceColor }}
+          />
           <TouchableOpacity 
-            style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.5)' }}
-            activeOpacity={1}
             onPress={() => setShowDatePicker(false)}
+            style={{ position: 'absolute', top: 0, right: 16 }}
           >
-            <TouchableOpacity 
-              activeOpacity={1}
-              onPress={() => {}}
-              style={{ backgroundColor: surfaceColor, borderRadius: 16, padding: 20, width: '85%' }}
-            >
-              <Text style={{ fontSize: 18, fontWeight: '600', color: textPrimary, marginBottom: 16, textAlign: 'center' }}>Select Date</Text>
-              
-              <View style={{ flexDirection: 'row', justifyContent: 'center', gap: 12, marginBottom: 20 }}>
-                <TouchableOpacity 
-                  onPress={() => {
-                    const today = new Date();
-                    setDate(today);
-                    setShowDatePicker(false);
-                  }}
-                  style={{ paddingVertical: 12, paddingHorizontal: 20, backgroundColor: COLORS.primary, borderRadius: 8 }}
-                >
-                  <Text style={{ color: '#FFFFFF', fontWeight: '600' }}>Today</Text>
-                </TouchableOpacity>
-                
-                <TouchableOpacity 
-                  onPress={() => {
-                    const yesterday = new Date();
-                    yesterday.setDate(yesterday.getDate() - 1);
-                    setDate(yesterday);
-                    setShowDatePicker(false);
-                  }}
-                  style={{ paddingVertical: 12, paddingHorizontal: 20, backgroundColor: isDark ? '#374151' : '#E5E7EB', borderRadius: 8 }}
-                >
-                  <Text style={{ color: textPrimary, fontWeight: '600' }}>Yesterday</Text>
-                </TouchableOpacity>
-              </View>
-              
-              <View style={{ borderTopWidth: 1, borderTopColor: borderColor, paddingTop: 16 }}>
-                <Text style={{ fontSize: 14, color: textSecondary, marginBottom: 8 }}>Or enter date:</Text>
-                <TextInput
-                  style={{
-                    borderWidth: 1,
-                    padding: 12,
-                    borderRadius: 8,
-                    backgroundColor: isDark ? COLORS.dark.background : COLORS.background,
-                    borderColor: borderColor,
-                    color: textPrimary,
-                    fontSize: 16,
-                  }}
-                  placeholder="DD/MM/YYYY"
-                  placeholderTextColor={textMuted}
-                  onChangeText={(text) => {
-                    const parts = text.split('/');
-                    if (parts.length === 3) {
-                      const day = parseInt(parts[0], 10);
-                      const month = parseInt(parts[1], 10) - 1;
-                      const year = parseInt(parts[2], 10);
-                      if (!isNaN(day) && !isNaN(month) && !isNaN(year)) {
-                        setDate(new Date(year, month, day));
-                      }
-                    }
-                  }}
-                />
-              </View>
-              
-              <TouchableOpacity 
-                onPress={() => setShowDatePicker(false)}
-                style={{ marginTop: 20, padding: 12, alignItems: 'center' }}
-              >
-                <Text style={{ color: COLORS.primary, fontSize: 16, fontWeight: '600' }}>Close</Text>
-              </TouchableOpacity>
-            </TouchableOpacity>
+            <Text style={{ color: COLORS.primary, fontSize: 16, fontWeight: '600' }}>Done</Text>
           </TouchableOpacity>
-        </Modal>
+        </View>
       )}
 
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Note (optional)</Text>

--- a/src/screens/AddExpenseScreen.tsx
+++ b/src/screens/AddExpenseScreen.tsx
@@ -171,34 +171,14 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
       </TouchableOpacity>
 
       {showDatePicker && (
-        <Modal
-          visible={true}
-          transparent={true}
-          animationType="slide"
-          onRequestClose={() => setShowDatePicker(false)}
-        >
-          <TouchableOpacity 
-            style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.4)' }} 
-            activeOpacity={1} 
-            onPress={() => setShowDatePicker(false)}
-          >
-            <View style={{ position: 'absolute', bottom: 0, left: 0, right: 0, backgroundColor: surfaceColor }}>
-              <View style={{ flexDirection: 'row', justifyContent: 'space-between', padding: 16, borderBottomWidth: 1, borderBottomColor: borderColor }}>
-                <TouchableOpacity onPress={() => setShowDatePicker(false)}>
-                  <Text style={{ color: textSecondary, fontSize: 16 }}>Cancel</Text>
-                </TouchableOpacity>
-                <Text style={{ color: textPrimary, fontSize: 18, fontWeight: '600' }}>Select Date</Text>
-                <View style={{ width: 60 }} />
-              </View>
-              <DateTimePicker
-                value={date}
-                mode="date"
-                display="spinner"
-                onChange={handleDateChange}
-              />
-            </View>
-          </TouchableOpacity>
-        </Modal>
+        <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, zIndex: 999 }}>
+          <DateTimePicker
+            value={date}
+            mode="date"
+            display="default"
+            onChange={handleDateChange}
+          />
+        </View>
       )}
 
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Note (optional)</Text>

--- a/src/screens/AddExpenseScreen.tsx
+++ b/src/screens/AddExpenseScreen.tsx
@@ -177,8 +177,12 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
           animationType="slide"
           onRequestClose={() => setShowDatePicker(false)}
         >
-          <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
-            <View style={{ backgroundColor: surfaceColor, paddingBottom: 40 }}>
+          <TouchableOpacity 
+            style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.4)' }} 
+            activeOpacity={1} 
+            onPress={() => setShowDatePicker(false)}
+          >
+            <View style={{ position: 'absolute', bottom: 0, left: 0, right: 0, backgroundColor: surfaceColor }}>
               <View style={{ flexDirection: 'row', justifyContent: 'space-between', padding: 16, borderBottomWidth: 1, borderBottomColor: borderColor }}>
                 <TouchableOpacity onPress={() => setShowDatePicker(false)}>
                   <Text style={{ color: textSecondary, fontSize: 16 }}>Cancel</Text>
@@ -191,11 +195,9 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
                 mode="date"
                 display="spinner"
                 onChange={handleDateChange}
-                themeVariant={isDark ? 'dark' : 'light'}
-                style={{ height: 200 }}
               />
             </View>
-          </View>
+          </TouchableOpacity>
         </Modal>
       )}
 

--- a/src/screens/AddExpenseScreen.tsx
+++ b/src/screens/AddExpenseScreen.tsx
@@ -8,7 +8,7 @@ import { COLORS } from '../constants/colors';
 import { AnimatedButton } from '../components/AnimatedButton';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
 import { useState } from 'react';
-import DateTimePicker from '@react-native-community/datetimepicker';
+import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 
 type AddExpenseScreenProps = {
   navigation: NativeStackNavigationProp<RootStackParamList, 'AddExpense'>;
@@ -142,11 +142,7 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
 
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Date</Text>
       <TouchableOpacity
-        onPress={() => {
-          if (Platform.OS === 'ios') {
-            setShowDatePicker(true);
-          }
-        }}
+        onPress={() => setShowDatePicker(true)}
         style={{
           borderWidth: 1,
           padding: 12,
@@ -163,39 +159,38 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
         <Ionicons name="calendar-outline" size={20} color={textSecondary} />
       </TouchableOpacity>
 
-      {Platform.OS === 'android' && (
-        <DateTimePicker
-          value={date}
-          mode="date"
-          display="default"
-          onChange={(event, selectedDate) => {
-            if (selectedDate) {
-              setDate(selectedDate);
-            }
-          }}
-        />
-      )}
-
-      {showDatePicker && Platform.OS === 'ios' && (
-        <View style={{ height: 300, marginBottom: 20 }}>
-          <DateTimePicker
-            value={date}
-            mode="date"
-            display="spinner"
-            onChange={(event, selectedDate) => {
-              if (selectedDate) {
-                setDate(selectedDate);
-              }
-            }}
-            style={{ backgroundColor: surfaceColor }}
-          />
-          <TouchableOpacity 
-            onPress={() => setShowDatePicker(false)}
-            style={{ position: 'absolute', top: 0, right: 16 }}
-          >
-            <Text style={{ color: COLORS.primary, fontSize: 16, fontWeight: '600' }}>Done</Text>
-          </TouchableOpacity>
-        </View>
+      {showDatePicker && (
+        <Modal
+          visible={true}
+          transparent={true}
+          animationType="slide"
+          onRequestClose={() => setShowDatePicker(false)}
+        >
+          <View style={{ flex: 1, justifyContent: 'flex-end' }}>
+            <View style={{ backgroundColor: surfaceColor, borderTopLeftRadius: 20, borderTopRightRadius: 20, paddingBottom: 40 }}>
+              <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 16, borderBottomWidth: 1, borderBottomColor: borderColor }}>
+                <TouchableOpacity onPress={() => setShowDatePicker(false)}>
+                  <Text style={{ color: textSecondary, fontSize: 16 }}>Cancel</Text>
+                </TouchableOpacity>
+                <Text style={{ color: textPrimary, fontSize: 18, fontWeight: '600' }}>Select Date</Text>
+                <TouchableOpacity onPress={() => setShowDatePicker(false)}>
+                  <Text style={{ color: COLORS.primary, fontSize: 16, fontWeight: '600' }}>Done</Text>
+                </TouchableOpacity>
+              </View>
+              <DateTimePicker
+                value={date}
+                mode="date"
+                display="spinner"
+                onChange={(event: DateTimePickerEvent, selectedDate?: Date) => {
+                  if (selectedDate) {
+                    setDate(selectedDate);
+                  }
+                }}
+                style={{ height: 200 }}
+              />
+            </View>
+          </View>
+        </Modal>
       )}
 
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Note (optional)</Text>

--- a/src/screens/AddExpenseScreen.tsx
+++ b/src/screens/AddExpenseScreen.tsx
@@ -106,6 +106,7 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
   };
 
   const handleDateChange = (event: any, selectedDate?: Date) => {
+    console.log('DateTimePicker onChange called', event, selectedDate);
     setShowDatePicker(false);
     if (selectedDate) {
       setDate(selectedDate);
@@ -149,7 +150,10 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
 
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Date</Text>
       <TouchableOpacity
-        onPress={() => setShowDatePicker(true)}
+        onPress={() => {
+          console.log('Date button pressed, setting showDatePicker to true');
+          setShowDatePicker(true);
+        }}
         style={{
           borderWidth: 1,
           padding: 12,
@@ -167,12 +171,22 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
       </TouchableOpacity>
 
       {showDatePicker && (
-        <DateTimePicker
-          value={date}
-          mode="date"
-          display="default"
-          onChange={handleDateChange}
-        />
+        <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.3)' }}>
+          <View style={{ backgroundColor: surfaceColor, padding: 20, borderRadius: 12 }}>
+            <DateTimePicker
+              value={date}
+              mode="date"
+              display="spinner"
+              onChange={handleDateChange}
+            />
+            <TouchableOpacity 
+              onPress={() => setShowDatePicker(false)}
+              style={{ padding: 10, alignItems: 'center' }}
+            >
+              <Text style={{ color: textPrimary, fontSize: 16 }}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
       )}
 
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Note (optional)</Text>

--- a/src/screens/AddExpenseScreen.tsx
+++ b/src/screens/AddExpenseScreen.tsx
@@ -7,7 +7,6 @@ import { CATEGORY_ICONS, CATEGORY_COLORS } from '../features/expense/constants/c
 import { COLORS } from '../constants/colors';
 import { AnimatedButton } from '../components/AnimatedButton';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
-import DateTimePicker from '@react-native-community/datetimepicker';
 import { useState } from 'react';
 
 type AddExpenseScreenProps = {
@@ -105,14 +104,6 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
     return d.toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric' });
   };
 
-  const handleDateChange = (event: any, selectedDate?: Date) => {
-    console.log('DateTimePicker onChange called', event, selectedDate);
-    setShowDatePicker(false);
-    if (selectedDate) {
-      setDate(selectedDate);
-    }
-  };
-
   return (
     <View style={{ flex: 1, padding: 16, backgroundColor }}>
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Amount</Text>
@@ -171,15 +162,86 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
       </TouchableOpacity>
 
       {showDatePicker && (
-        <View style={{ height: 300, backgroundColor: surfaceColor, marginBottom: 20, borderRadius: 8, overflow: 'hidden' }}>
-          <DateTimePicker
-            key={date.toISOString()}
-            value={date}
-            mode="date"
-            display="spinner"
-            onChange={handleDateChange}
-          />
-        </View>
+        <Modal
+          visible={true}
+          transparent={true}
+          animationType="fade"
+          onRequestClose={() => setShowDatePicker(false)}
+        >
+          <TouchableOpacity 
+            style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.5)' }}
+            activeOpacity={1}
+            onPress={() => setShowDatePicker(false)}
+          >
+            <TouchableOpacity 
+              activeOpacity={1}
+              onPress={() => {}}
+              style={{ backgroundColor: surfaceColor, borderRadius: 16, padding: 20, width: '85%' }}
+            >
+              <Text style={{ fontSize: 18, fontWeight: '600', color: textPrimary, marginBottom: 16, textAlign: 'center' }}>Select Date</Text>
+              
+              <View style={{ flexDirection: 'row', justifyContent: 'center', gap: 12, marginBottom: 20 }}>
+                <TouchableOpacity 
+                  onPress={() => {
+                    const today = new Date();
+                    setDate(today);
+                    setShowDatePicker(false);
+                  }}
+                  style={{ paddingVertical: 12, paddingHorizontal: 20, backgroundColor: COLORS.primary, borderRadius: 8 }}
+                >
+                  <Text style={{ color: '#FFFFFF', fontWeight: '600' }}>Today</Text>
+                </TouchableOpacity>
+                
+                <TouchableOpacity 
+                  onPress={() => {
+                    const yesterday = new Date();
+                    yesterday.setDate(yesterday.getDate() - 1);
+                    setDate(yesterday);
+                    setShowDatePicker(false);
+                  }}
+                  style={{ paddingVertical: 12, paddingHorizontal: 20, backgroundColor: isDark ? '#374151' : '#E5E7EB', borderRadius: 8 }}
+                >
+                  <Text style={{ color: textPrimary, fontWeight: '600' }}>Yesterday</Text>
+                </TouchableOpacity>
+              </View>
+              
+              <View style={{ borderTopWidth: 1, borderTopColor: borderColor, paddingTop: 16 }}>
+                <Text style={{ fontSize: 14, color: textSecondary, marginBottom: 8 }}>Or enter date:</Text>
+                <TextInput
+                  style={{
+                    borderWidth: 1,
+                    padding: 12,
+                    borderRadius: 8,
+                    backgroundColor: isDark ? COLORS.dark.background : COLORS.background,
+                    borderColor: borderColor,
+                    color: textPrimary,
+                    fontSize: 16,
+                  }}
+                  placeholder="DD/MM/YYYY"
+                  placeholderTextColor={textMuted}
+                  onChangeText={(text) => {
+                    const parts = text.split('/');
+                    if (parts.length === 3) {
+                      const day = parseInt(parts[0], 10);
+                      const month = parseInt(parts[1], 10) - 1;
+                      const year = parseInt(parts[2], 10);
+                      if (!isNaN(day) && !isNaN(month) && !isNaN(year)) {
+                        setDate(new Date(year, month, day));
+                      }
+                    }
+                  }}
+                />
+              </View>
+              
+              <TouchableOpacity 
+                onPress={() => setShowDatePicker(false)}
+                style={{ marginTop: 20, padding: 12, alignItems: 'center' }}
+              >
+                <Text style={{ color: COLORS.primary, fontSize: 16, fontWeight: '600' }}>Close</Text>
+              </TouchableOpacity>
+            </TouchableOpacity>
+          </TouchableOpacity>
+        </Modal>
       )}
 
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Note (optional)</Text>

--- a/src/screens/AddExpenseScreen.tsx
+++ b/src/screens/AddExpenseScreen.tsx
@@ -171,15 +171,32 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
       </TouchableOpacity>
 
       {showDatePicker && (
-        <View style={{ marginBottom: 20 }}>
-          <DateTimePicker
-            value={date}
-            mode="date"
-            display="spinner"
-            onChange={handleDateChange}
-            themeVariant={isDark ? 'dark' : 'light'}
-          />
-        </View>
+        <Modal
+          visible={true}
+          transparent={true}
+          animationType="slide"
+          onRequestClose={() => setShowDatePicker(false)}
+        >
+          <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
+            <View style={{ backgroundColor: surfaceColor, paddingBottom: 40 }}>
+              <View style={{ flexDirection: 'row', justifyContent: 'space-between', padding: 16, borderBottomWidth: 1, borderBottomColor: borderColor }}>
+                <TouchableOpacity onPress={() => setShowDatePicker(false)}>
+                  <Text style={{ color: textSecondary, fontSize: 16 }}>Cancel</Text>
+                </TouchableOpacity>
+                <Text style={{ color: textPrimary, fontSize: 18, fontWeight: '600' }}>Select Date</Text>
+                <View style={{ width: 60 }} />
+              </View>
+              <DateTimePicker
+                value={date}
+                mode="date"
+                display="spinner"
+                onChange={handleDateChange}
+                themeVariant={isDark ? 'dark' : 'light'}
+                style={{ height: 200 }}
+              />
+            </View>
+          </View>
+        </Modal>
       )}
 
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Note (optional)</Text>

--- a/src/screens/AddExpenseScreen.tsx
+++ b/src/screens/AddExpenseScreen.tsx
@@ -177,17 +177,19 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
                   <Text style={{ color: COLORS.primary, fontSize: 16, fontWeight: '600' }}>Done</Text>
                 </TouchableOpacity>
               </View>
-              <DateTimePicker
-                value={date}
-                mode="date"
-                display="default"
-                onChange={(event: DateTimePickerEvent, selectedDate?: Date) => {
-                  if (selectedDate) {
-                    setDate(selectedDate);
-                  }
-                }}
-                style={{ height: 200 }}
-              />
+              {(Platform.OS === 'ios' || Platform.OS === 'android') && (
+                <DateTimePicker
+                  value={date}
+                  mode="date"
+                  display="default"
+                  onChange={(event: DateTimePickerEvent, selectedDate?: Date) => {
+                    if (selectedDate) {
+                      setDate(selectedDate);
+                    }
+                  }}
+                  style={{ height: 200 }}
+                />
+              )}
             </View>
           </View>
         </Modal>

--- a/src/screens/AddExpenseScreen.tsx
+++ b/src/screens/AddExpenseScreen.tsx
@@ -1,4 +1,4 @@
-import { Text, View, TextInput, TouchableOpacity, ColorSchemeName } from 'react-native';
+import { Text, View, TextInput, TouchableOpacity, ColorSchemeName, Modal } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../navigation/AppNavigator';
@@ -7,6 +7,8 @@ import { CATEGORY_ICONS, CATEGORY_COLORS } from '../features/expense/constants/c
 import { COLORS } from '../constants/colors';
 import { AnimatedButton } from '../components/AnimatedButton';
 import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { useState } from 'react';
 
 type AddExpenseScreenProps = {
   navigation: NativeStackNavigationProp<RootStackParamList, 'AddExpense'>;
@@ -83,7 +85,8 @@ function CategoryChip({
 export default function AddExpenseScreen({ navigation, colorScheme }: AddExpenseScreenProps) {
   const isDark = colorScheme === 'dark';
   
-  const { amount, setAmount, category, setCategory, note, setNote, handleSave } = useAddExpense(navigation);
+  const { amount, setAmount, category, setCategory, note, setNote, date, setDate, handleSave } = useAddExpense(navigation);
+  const [showDatePicker, setShowDatePicker] = useState(false);
 
   const backgroundColor = isDark ? COLORS.dark.background : COLORS.background;
   const surfaceColor = isDark ? COLORS.dark.surface : COLORS.surface;
@@ -91,6 +94,23 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
   const textSecondary = isDark ? COLORS.dark.text.secondary : COLORS.text.secondary;
   const textMuted = isDark ? COLORS.dark.text.muted : COLORS.text.muted;
   const borderColor = isDark ? COLORS.dark.border : COLORS.border;
+
+  const formatDisplayDate = (d: Date) => {
+    const today = new Date();
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    if (d.toDateString() === today.toDateString()) return 'Today';
+    if (d.toDateString() === yesterday.toDateString()) return 'Yesterday';
+    return d.toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric' });
+  };
+
+  const handleDateChange = (event: any, selectedDate?: Date) => {
+    setShowDatePicker(false);
+    if (selectedDate) {
+      setDate(selectedDate);
+    }
+  };
 
   return (
     <View style={{ flex: 1, padding: 16, backgroundColor }}>
@@ -126,6 +146,34 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
           />
         ))}
       </View>
+
+      <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Date</Text>
+      <TouchableOpacity
+        onPress={() => setShowDatePicker(true)}
+        style={{
+          borderWidth: 1,
+          padding: 12,
+          marginBottom: 20,
+          borderRadius: 8,
+          backgroundColor: surfaceColor,
+          borderColor: borderColor,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Text style={{ color: textPrimary, fontSize: 16 }}>{formatDisplayDate(date)}</Text>
+        <Ionicons name="calendar-outline" size={20} color={textSecondary} />
+      </TouchableOpacity>
+
+      {showDatePicker && (
+        <DateTimePicker
+          value={date}
+          mode="date"
+          display="default"
+          onChange={handleDateChange}
+        />
+      )}
 
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Note (optional)</Text>
       <TextInput

--- a/src/screens/AddExpenseScreen.tsx
+++ b/src/screens/AddExpenseScreen.tsx
@@ -171,12 +171,15 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
       </TouchableOpacity>
 
       {showDatePicker && (
-        <DateTimePicker
-          value={date}
-          mode="date"
-          display="inline"
-          onChange={handleDateChange}
-        />
+        <View style={{ height: 300, backgroundColor: surfaceColor, marginBottom: 20, borderRadius: 8, overflow: 'hidden' }}>
+          <DateTimePicker
+            key={date.toISOString()}
+            value={date}
+            mode="date"
+            display="spinner"
+            onChange={handleDateChange}
+          />
+        </View>
       )}
 
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Note (optional)</Text>

--- a/src/screens/AddExpenseScreen.tsx
+++ b/src/screens/AddExpenseScreen.tsx
@@ -171,21 +171,14 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
       </TouchableOpacity>
 
       {showDatePicker && (
-        <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.3)' }}>
-          <View style={{ backgroundColor: surfaceColor, padding: 20, borderRadius: 12 }}>
-            <DateTimePicker
-              value={date}
-              mode="date"
-              display="spinner"
-              onChange={handleDateChange}
-            />
-            <TouchableOpacity 
-              onPress={() => setShowDatePicker(false)}
-              style={{ padding: 10, alignItems: 'center' }}
-            >
-              <Text style={{ color: textPrimary, fontSize: 16 }}>Cancel</Text>
-            </TouchableOpacity>
-          </View>
+        <View style={{ marginBottom: 20 }}>
+          <DateTimePicker
+            value={date}
+            mode="date"
+            display="spinner"
+            onChange={handleDateChange}
+            themeVariant={isDark ? 'dark' : 'light'}
+          />
         </View>
       )}
 

--- a/src/screens/AddExpenseScreen.tsx
+++ b/src/screens/AddExpenseScreen.tsx
@@ -180,7 +180,7 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
               <DateTimePicker
                 value={date}
                 mode="date"
-                display="spinner"
+                display="default"
                 onChange={(event: DateTimePickerEvent, selectedDate?: Date) => {
                   if (selectedDate) {
                     setDate(selectedDate);

--- a/src/screens/AddExpenseScreen.tsx
+++ b/src/screens/AddExpenseScreen.tsx
@@ -171,14 +171,12 @@ export default function AddExpenseScreen({ navigation, colorScheme }: AddExpense
       </TouchableOpacity>
 
       {showDatePicker && (
-        <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, zIndex: 999 }}>
-          <DateTimePicker
-            value={date}
-            mode="date"
-            display="default"
-            onChange={handleDateChange}
-          />
-        </View>
+        <DateTimePicker
+          value={date}
+          mode="date"
+          display="inline"
+          onChange={handleDateChange}
+        />
       )}
 
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Note (optional)</Text>

--- a/src/screens/EditExpenseScreen.tsx
+++ b/src/screens/EditExpenseScreen.tsx
@@ -11,6 +11,7 @@ import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-na
 import { useExpenseStore } from '../features/expense/hooks/useExpenseStore';
 import type { Expense } from '../features/expense/types';
 import { formatRupiah, parseRupiah } from '../utils/currency';
+import DateTimePicker from '@react-native-community/datetimepicker';
 
 type EditExpenseScreenProps = {
   navigation: NativeStackNavigationProp<RootStackParamList, 'EditExpense'>;
@@ -97,12 +98,15 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
   const [amount, setAmount] = useState(existingExpense ? formatRupiah(existingExpense.amount) : '');
   const [category, setCategory] = useState(existingExpense?.category || CATEGORIES[0]);
   const [note, setNote] = useState(existingExpense?.note || '');
+  const [date, setDate] = useState(existingExpense ? new Date(existingExpense.date) : new Date());
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [showDatePicker, setShowDatePicker] = useState(false);
 
   const hasChanges = existingExpense && (
     parseRupiah(amount) !== existingExpense.amount ||
     category !== existingExpense.category ||
-    note !== (existingExpense.note || '')
+    note !== (existingExpense.note || '') ||
+    date.toISOString().split('T')[0] !== new Date(existingExpense.date).toISOString().split('T')[0]
   );
 
   const handleAmountChange = (value: string) => {
@@ -122,31 +126,39 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
       amount: numericAmount,
       category,
       note,
+      date: date.toISOString(),
     });
     
     navigation.goBack();
   };
 
   const confirmDelete = () => {
-    console.log('Delete confirmed, calling deleteExpense with:', expenseId);
-    console.log('Current expenses before delete:', useExpenseStore.getState().expenses);
     if (expenseId) {
-      console.log('About to call deleteExpense');
       deleteExpense(expenseId);
-      console.log('After deleteExpense call');
-      console.log('Expenses after delete:', useExpenseStore.getState().expenses);
       setShowDeleteModal(false);
       navigation.goBack();
-    } else {
-      console.log('expenseId is falsy:', expenseId);
     }
   };
 
   const handleDeletePress = () => {
-    console.log('handleDelete called, expenseId:', expenseId);
-    console.log('About to show delete modal');
     setShowDeleteModal(true);
-    console.log('Modal should be shown now');
+  };
+
+  const formatDisplayDate = (d: Date) => {
+    const today = new Date();
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    if (d.toDateString() === today.toDateString()) return 'Today';
+    if (d.toDateString() === yesterday.toDateString()) return 'Yesterday';
+    return d.toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric' });
+  };
+
+  const handleDateChange = (event: any, selectedDate?: Date) => {
+    setShowDatePicker(false);
+    if (selectedDate) {
+      setDate(selectedDate);
+    }
   };
 
   const backgroundColor = isDark ? COLORS.dark.background : COLORS.background;
@@ -208,6 +220,34 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
         placeholder="Enter note"
         placeholderTextColor={textMuted}
       />
+
+      <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Date</Text>
+      <TouchableOpacity
+        onPress={() => setShowDatePicker(true)}
+        style={{
+          borderWidth: 1,
+          padding: 12,
+          marginBottom: 20,
+          borderRadius: 8,
+          backgroundColor: surfaceColor,
+          borderColor: borderColor,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Text style={{ color: textPrimary, fontSize: 16 }}>{formatDisplayDate(date)}</Text>
+        <Ionicons name="calendar-outline" size={20} color={textSecondary} />
+      </TouchableOpacity>
+
+      {showDatePicker && (
+        <DateTimePicker
+          value={date}
+          mode="date"
+          display="default"
+          onChange={handleDateChange}
+        />
+      )}
 
       {hasChanges ? (
         <AnimatedButton 

--- a/src/screens/EditExpenseScreen.tsx
+++ b/src/screens/EditExpenseScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { Text, View, TextInput, TouchableOpacity, ColorSchemeName, Modal } from 'react-native';
+import { Text, View, TextInput, TouchableOpacity, ColorSchemeName, Modal, Platform } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../navigation/AppNavigator';
@@ -251,17 +251,19 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
                   <Text style={{ color: COLORS.primary, fontSize: 16, fontWeight: '600' }}>Done</Text>
                 </TouchableOpacity>
               </View>
-              <DateTimePicker
-                value={date}
-                mode="date"
-                display="default"
-                onChange={(event: DateTimePickerEvent, selectedDate?: Date) => {
-                  if (selectedDate) {
-                    setDate(selectedDate);
-                  }
-                }}
-                style={{ height: 200 }}
-              />
+              {(Platform.OS === 'ios' || Platform.OS === 'android') && (
+                <DateTimePicker
+                  value={date}
+                  mode="date"
+                  display="default"
+                  onChange={(event: DateTimePickerEvent, selectedDate?: Date) => {
+                    if (selectedDate) {
+                      setDate(selectedDate);
+                    }
+                  }}
+                  style={{ height: 200 }}
+                />
+              )}
             </View>
           </View>
         </Modal>

--- a/src/screens/EditExpenseScreen.tsx
+++ b/src/screens/EditExpenseScreen.tsx
@@ -245,15 +245,32 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
       </TouchableOpacity>
 
       {showDatePicker && (
-        <View style={{ marginBottom: 20 }}>
-          <DateTimePicker
-            value={date}
-            mode="date"
-            display="spinner"
-            onChange={handleDateChange}
-            themeVariant={isDark ? 'dark' : 'light'}
-          />
-        </View>
+        <Modal
+          visible={true}
+          transparent={true}
+          animationType="slide"
+          onRequestClose={() => setShowDatePicker(false)}
+        >
+          <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
+            <View style={{ backgroundColor: surfaceColor, paddingBottom: 40 }}>
+              <View style={{ flexDirection: 'row', justifyContent: 'space-between', padding: 16, borderBottomWidth: 1, borderBottomColor: borderColor }}>
+                <TouchableOpacity onPress={() => setShowDatePicker(false)}>
+                  <Text style={{ color: textSecondary, fontSize: 16 }}>Cancel</Text>
+                </TouchableOpacity>
+                <Text style={{ color: textPrimary, fontSize: 18, fontWeight: '600' }}>Select Date</Text>
+                <View style={{ width: 60 }} />
+              </View>
+              <DateTimePicker
+                value={date}
+                mode="date"
+                display="spinner"
+                onChange={handleDateChange}
+                themeVariant={isDark ? 'dark' : 'light'}
+                style={{ height: 200 }}
+              />
+            </View>
+          </View>
+        </Modal>
       )}
 
       {hasChanges ? (

--- a/src/screens/EditExpenseScreen.tsx
+++ b/src/screens/EditExpenseScreen.tsx
@@ -245,12 +245,15 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
       </TouchableOpacity>
 
       {showDatePicker && (
-        <DateTimePicker
-          value={date}
-          mode="date"
-          display="inline"
-          onChange={handleDateChange}
-        />
+        <View style={{ height: 300, backgroundColor: surfaceColor, marginBottom: 20, borderRadius: 8, overflow: 'hidden' }}>
+          <DateTimePicker
+            key={date.toISOString()}
+            value={date}
+            mode="date"
+            display="spinner"
+            onChange={handleDateChange}
+          />
+        </View>
       )}
 
       {hasChanges ? (

--- a/src/screens/EditExpenseScreen.tsx
+++ b/src/screens/EditExpenseScreen.tsx
@@ -245,14 +245,12 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
       </TouchableOpacity>
 
       {showDatePicker && (
-        <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, zIndex: 999 }}>
-          <DateTimePicker
-            value={date}
-            mode="date"
-            display="default"
-            onChange={handleDateChange}
-          />
-        </View>
+        <DateTimePicker
+          value={date}
+          mode="date"
+          display="inline"
+          onChange={handleDateChange}
+        />
       )}
 
       {hasChanges ? (

--- a/src/screens/EditExpenseScreen.tsx
+++ b/src/screens/EditExpenseScreen.tsx
@@ -251,8 +251,12 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
           animationType="slide"
           onRequestClose={() => setShowDatePicker(false)}
         >
-          <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
-            <View style={{ backgroundColor: surfaceColor, paddingBottom: 40 }}>
+          <TouchableOpacity 
+            style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.4)' }} 
+            activeOpacity={1} 
+            onPress={() => setShowDatePicker(false)}
+          >
+            <View style={{ position: 'absolute', bottom: 0, left: 0, right: 0, backgroundColor: surfaceColor }}>
               <View style={{ flexDirection: 'row', justifyContent: 'space-between', padding: 16, borderBottomWidth: 1, borderBottomColor: borderColor }}>
                 <TouchableOpacity onPress={() => setShowDatePicker(false)}>
                   <Text style={{ color: textSecondary, fontSize: 16 }}>Cancel</Text>
@@ -265,11 +269,9 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
                 mode="date"
                 display="spinner"
                 onChange={handleDateChange}
-                themeVariant={isDark ? 'dark' : 'light'}
-                style={{ height: 200 }}
               />
             </View>
-          </View>
+          </TouchableOpacity>
         </Modal>
       )}
 

--- a/src/screens/EditExpenseScreen.tsx
+++ b/src/screens/EditExpenseScreen.tsx
@@ -254,7 +254,7 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
               <DateTimePicker
                 value={date}
                 mode="date"
-                display="spinner"
+                display="default"
                 onChange={(event: DateTimePickerEvent, selectedDate?: Date) => {
                   if (selectedDate) {
                     setDate(selectedDate);

--- a/src/screens/EditExpenseScreen.tsx
+++ b/src/screens/EditExpenseScreen.tsx
@@ -11,7 +11,6 @@ import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-na
 import { useExpenseStore } from '../features/expense/hooks/useExpenseStore';
 import type { Expense } from '../features/expense/types';
 import { formatRupiah, parseRupiah } from '../utils/currency';
-import DateTimePicker from '@react-native-community/datetimepicker';
 
 type EditExpenseScreenProps = {
   navigation: NativeStackNavigationProp<RootStackParamList, 'EditExpense'>;
@@ -154,14 +153,6 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
     return d.toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric' });
   };
 
-  const handleDateChange = (event: any, selectedDate?: Date) => {
-    console.log('DateTimePicker onChange called', event, selectedDate);
-    setShowDatePicker(false);
-    if (selectedDate) {
-      setDate(selectedDate);
-    }
-  };
-
   const backgroundColor = isDark ? COLORS.dark.background : COLORS.background;
   const surfaceColor = isDark ? COLORS.dark.surface : COLORS.surface;
   const textPrimary = isDark ? COLORS.dark.text.primary : COLORS.text.primary;
@@ -245,15 +236,86 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
       </TouchableOpacity>
 
       {showDatePicker && (
-        <View style={{ height: 300, backgroundColor: surfaceColor, marginBottom: 20, borderRadius: 8, overflow: 'hidden' }}>
-          <DateTimePicker
-            key={date.toISOString()}
-            value={date}
-            mode="date"
-            display="spinner"
-            onChange={handleDateChange}
-          />
-        </View>
+        <Modal
+          visible={true}
+          transparent={true}
+          animationType="fade"
+          onRequestClose={() => setShowDatePicker(false)}
+        >
+          <TouchableOpacity 
+            style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.5)' }}
+            activeOpacity={1}
+            onPress={() => setShowDatePicker(false)}
+          >
+            <TouchableOpacity 
+              activeOpacity={1}
+              onPress={() => {}}
+              style={{ backgroundColor: surfaceColor, borderRadius: 16, padding: 20, width: '85%' }}
+            >
+              <Text style={{ fontSize: 18, fontWeight: '600', color: textPrimary, marginBottom: 16, textAlign: 'center' }}>Select Date</Text>
+              
+              <View style={{ flexDirection: 'row', justifyContent: 'center', gap: 12, marginBottom: 20 }}>
+                <TouchableOpacity 
+                  onPress={() => {
+                    const today = new Date();
+                    setDate(today);
+                    setShowDatePicker(false);
+                  }}
+                  style={{ paddingVertical: 12, paddingHorizontal: 20, backgroundColor: COLORS.primary, borderRadius: 8 }}
+                >
+                  <Text style={{ color: '#FFFFFF', fontWeight: '600' }}>Today</Text>
+                </TouchableOpacity>
+                
+                <TouchableOpacity 
+                  onPress={() => {
+                    const yesterday = new Date();
+                    yesterday.setDate(yesterday.getDate() - 1);
+                    setDate(yesterday);
+                    setShowDatePicker(false);
+                  }}
+                  style={{ paddingVertical: 12, paddingHorizontal: 20, backgroundColor: isDark ? '#374151' : '#E5E7EB', borderRadius: 8 }}
+                >
+                  <Text style={{ color: textPrimary, fontWeight: '600' }}>Yesterday</Text>
+                </TouchableOpacity>
+              </View>
+              
+              <View style={{ borderTopWidth: 1, borderTopColor: borderColor, paddingTop: 16 }}>
+                <Text style={{ fontSize: 14, color: textSecondary, marginBottom: 8 }}>Or enter date:</Text>
+                <TextInput
+                  style={{
+                    borderWidth: 1,
+                    padding: 12,
+                    borderRadius: 8,
+                    backgroundColor: isDark ? COLORS.dark.background : COLORS.background,
+                    borderColor: borderColor,
+                    color: textPrimary,
+                    fontSize: 16,
+                  }}
+                  placeholder="DD/MM/YYYY"
+                  placeholderTextColor={textMuted}
+                  onChangeText={(text) => {
+                    const parts = text.split('/');
+                    if (parts.length === 3) {
+                      const day = parseInt(parts[0], 10);
+                      const month = parseInt(parts[1], 10) - 1;
+                      const year = parseInt(parts[2], 10);
+                      if (!isNaN(day) && !isNaN(month) && !isNaN(year)) {
+                        setDate(new Date(year, month, day));
+                      }
+                    }
+                  }}
+                />
+              </View>
+              
+              <TouchableOpacity 
+                onPress={() => setShowDatePicker(false)}
+                style={{ marginTop: 20, padding: 12, alignItems: 'center' }}
+              >
+                <Text style={{ color: COLORS.primary, fontSize: 16, fontWeight: '600' }}>Close</Text>
+              </TouchableOpacity>
+            </TouchableOpacity>
+          </TouchableOpacity>
+        </Modal>
       )}
 
       {hasChanges ? (

--- a/src/screens/EditExpenseScreen.tsx
+++ b/src/screens/EditExpenseScreen.tsx
@@ -245,34 +245,14 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
       </TouchableOpacity>
 
       {showDatePicker && (
-        <Modal
-          visible={true}
-          transparent={true}
-          animationType="slide"
-          onRequestClose={() => setShowDatePicker(false)}
-        >
-          <TouchableOpacity 
-            style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.4)' }} 
-            activeOpacity={1} 
-            onPress={() => setShowDatePicker(false)}
-          >
-            <View style={{ position: 'absolute', bottom: 0, left: 0, right: 0, backgroundColor: surfaceColor }}>
-              <View style={{ flexDirection: 'row', justifyContent: 'space-between', padding: 16, borderBottomWidth: 1, borderBottomColor: borderColor }}>
-                <TouchableOpacity onPress={() => setShowDatePicker(false)}>
-                  <Text style={{ color: textSecondary, fontSize: 16 }}>Cancel</Text>
-                </TouchableOpacity>
-                <Text style={{ color: textPrimary, fontSize: 18, fontWeight: '600' }}>Select Date</Text>
-                <View style={{ width: 60 }} />
-              </View>
-              <DateTimePicker
-                value={date}
-                mode="date"
-                display="spinner"
-                onChange={handleDateChange}
-              />
-            </View>
-          </TouchableOpacity>
-        </Modal>
+        <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, zIndex: 999 }}>
+          <DateTimePicker
+            value={date}
+            mode="date"
+            display="default"
+            onChange={handleDateChange}
+          />
+        </View>
       )}
 
       {hasChanges ? (

--- a/src/screens/EditExpenseScreen.tsx
+++ b/src/screens/EditExpenseScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { Text, View, TextInput, TouchableOpacity, ColorSchemeName, Modal } from 'react-native';
+import { Text, View, TextInput, TouchableOpacity, ColorSchemeName, Modal, Platform } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../navigation/AppNavigator';
@@ -11,6 +11,7 @@ import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-na
 import { useExpenseStore } from '../features/expense/hooks/useExpenseStore';
 import type { Expense } from '../features/expense/types';
 import { formatRupiah, parseRupiah } from '../utils/currency';
+import DateTimePicker from '@react-native-community/datetimepicker';
 
 type EditExpenseScreenProps = {
   navigation: NativeStackNavigationProp<RootStackParamList, 'EditExpense'>;
@@ -216,8 +217,9 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Date</Text>
       <TouchableOpacity
         onPress={() => {
-          console.log('Date button pressed, setting showDatePicker to true');
-          setShowDatePicker(true);
+          if (Platform.OS === 'ios') {
+            setShowDatePicker(true);
+          }
         }}
         style={{
           borderWidth: 1,
@@ -235,87 +237,39 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
         <Ionicons name="calendar-outline" size={20} color={textSecondary} />
       </TouchableOpacity>
 
-      {showDatePicker && (
-        <Modal
-          visible={true}
-          transparent={true}
-          animationType="fade"
-          onRequestClose={() => setShowDatePicker(false)}
-        >
+      {Platform.OS === 'android' && (
+        <DateTimePicker
+          value={date}
+          mode="date"
+          display="default"
+          onChange={(event, selectedDate) => {
+            if (selectedDate) {
+              setDate(selectedDate);
+            }
+          }}
+        />
+      )}
+
+      {showDatePicker && Platform.OS === 'ios' && (
+        <View style={{ height: 300, marginBottom: 20 }}>
+          <DateTimePicker
+            value={date}
+            mode="date"
+            display="spinner"
+            onChange={(event, selectedDate) => {
+              if (selectedDate) {
+                setDate(selectedDate);
+              }
+            }}
+            style={{ backgroundColor: surfaceColor }}
+          />
           <TouchableOpacity 
-            style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.5)' }}
-            activeOpacity={1}
             onPress={() => setShowDatePicker(false)}
+            style={{ position: 'absolute', top: 0, right: 16 }}
           >
-            <TouchableOpacity 
-              activeOpacity={1}
-              onPress={() => {}}
-              style={{ backgroundColor: surfaceColor, borderRadius: 16, padding: 20, width: '85%' }}
-            >
-              <Text style={{ fontSize: 18, fontWeight: '600', color: textPrimary, marginBottom: 16, textAlign: 'center' }}>Select Date</Text>
-              
-              <View style={{ flexDirection: 'row', justifyContent: 'center', gap: 12, marginBottom: 20 }}>
-                <TouchableOpacity 
-                  onPress={() => {
-                    const today = new Date();
-                    setDate(today);
-                    setShowDatePicker(false);
-                  }}
-                  style={{ paddingVertical: 12, paddingHorizontal: 20, backgroundColor: COLORS.primary, borderRadius: 8 }}
-                >
-                  <Text style={{ color: '#FFFFFF', fontWeight: '600' }}>Today</Text>
-                </TouchableOpacity>
-                
-                <TouchableOpacity 
-                  onPress={() => {
-                    const yesterday = new Date();
-                    yesterday.setDate(yesterday.getDate() - 1);
-                    setDate(yesterday);
-                    setShowDatePicker(false);
-                  }}
-                  style={{ paddingVertical: 12, paddingHorizontal: 20, backgroundColor: isDark ? '#374151' : '#E5E7EB', borderRadius: 8 }}
-                >
-                  <Text style={{ color: textPrimary, fontWeight: '600' }}>Yesterday</Text>
-                </TouchableOpacity>
-              </View>
-              
-              <View style={{ borderTopWidth: 1, borderTopColor: borderColor, paddingTop: 16 }}>
-                <Text style={{ fontSize: 14, color: textSecondary, marginBottom: 8 }}>Or enter date:</Text>
-                <TextInput
-                  style={{
-                    borderWidth: 1,
-                    padding: 12,
-                    borderRadius: 8,
-                    backgroundColor: isDark ? COLORS.dark.background : COLORS.background,
-                    borderColor: borderColor,
-                    color: textPrimary,
-                    fontSize: 16,
-                  }}
-                  placeholder="DD/MM/YYYY"
-                  placeholderTextColor={textMuted}
-                  onChangeText={(text) => {
-                    const parts = text.split('/');
-                    if (parts.length === 3) {
-                      const day = parseInt(parts[0], 10);
-                      const month = parseInt(parts[1], 10) - 1;
-                      const year = parseInt(parts[2], 10);
-                      if (!isNaN(day) && !isNaN(month) && !isNaN(year)) {
-                        setDate(new Date(year, month, day));
-                      }
-                    }
-                  }}
-                />
-              </View>
-              
-              <TouchableOpacity 
-                onPress={() => setShowDatePicker(false)}
-                style={{ marginTop: 20, padding: 12, alignItems: 'center' }}
-              >
-                <Text style={{ color: COLORS.primary, fontSize: 16, fontWeight: '600' }}>Close</Text>
-              </TouchableOpacity>
-            </TouchableOpacity>
+            <Text style={{ color: COLORS.primary, fontSize: 16, fontWeight: '600' }}>Done</Text>
           </TouchableOpacity>
-        </Modal>
+        </View>
       )}
 
       {hasChanges ? (

--- a/src/screens/EditExpenseScreen.tsx
+++ b/src/screens/EditExpenseScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react';
-import { Text, View, TextInput, TouchableOpacity, ColorSchemeName, Modal, Platform } from 'react-native';
+import { Text, View, TextInput, TouchableOpacity, ColorSchemeName, Modal } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../navigation/AppNavigator';
@@ -11,7 +11,7 @@ import Animated, { useAnimatedStyle, useSharedValue, withSpring } from 'react-na
 import { useExpenseStore } from '../features/expense/hooks/useExpenseStore';
 import type { Expense } from '../features/expense/types';
 import { formatRupiah, parseRupiah } from '../utils/currency';
-import DateTimePicker from '@react-native-community/datetimepicker';
+import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 
 type EditExpenseScreenProps = {
   navigation: NativeStackNavigationProp<RootStackParamList, 'EditExpense'>;
@@ -216,11 +216,7 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
 
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Date</Text>
       <TouchableOpacity
-        onPress={() => {
-          if (Platform.OS === 'ios') {
-            setShowDatePicker(true);
-          }
-        }}
+        onPress={() => setShowDatePicker(true)}
         style={{
           borderWidth: 1,
           padding: 12,
@@ -237,39 +233,38 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
         <Ionicons name="calendar-outline" size={20} color={textSecondary} />
       </TouchableOpacity>
 
-      {Platform.OS === 'android' && (
-        <DateTimePicker
-          value={date}
-          mode="date"
-          display="default"
-          onChange={(event, selectedDate) => {
-            if (selectedDate) {
-              setDate(selectedDate);
-            }
-          }}
-        />
-      )}
-
-      {showDatePicker && Platform.OS === 'ios' && (
-        <View style={{ height: 300, marginBottom: 20 }}>
-          <DateTimePicker
-            value={date}
-            mode="date"
-            display="spinner"
-            onChange={(event, selectedDate) => {
-              if (selectedDate) {
-                setDate(selectedDate);
-              }
-            }}
-            style={{ backgroundColor: surfaceColor }}
-          />
-          <TouchableOpacity 
-            onPress={() => setShowDatePicker(false)}
-            style={{ position: 'absolute', top: 0, right: 16 }}
-          >
-            <Text style={{ color: COLORS.primary, fontSize: 16, fontWeight: '600' }}>Done</Text>
-          </TouchableOpacity>
-        </View>
+      {showDatePicker && (
+        <Modal
+          visible={true}
+          transparent={true}
+          animationType="slide"
+          onRequestClose={() => setShowDatePicker(false)}
+        >
+          <View style={{ flex: 1, justifyContent: 'flex-end' }}>
+            <View style={{ backgroundColor: surfaceColor, borderTopLeftRadius: 20, borderTopRightRadius: 20, paddingBottom: 40 }}>
+              <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', padding: 16, borderBottomWidth: 1, borderBottomColor: borderColor }}>
+                <TouchableOpacity onPress={() => setShowDatePicker(false)}>
+                  <Text style={{ color: textSecondary, fontSize: 16 }}>Cancel</Text>
+                </TouchableOpacity>
+                <Text style={{ color: textPrimary, fontSize: 18, fontWeight: '600' }}>Select Date</Text>
+                <TouchableOpacity onPress={() => setShowDatePicker(false)}>
+                  <Text style={{ color: COLORS.primary, fontSize: 16, fontWeight: '600' }}>Done</Text>
+                </TouchableOpacity>
+              </View>
+              <DateTimePicker
+                value={date}
+                mode="date"
+                display="spinner"
+                onChange={(event: DateTimePickerEvent, selectedDate?: Date) => {
+                  if (selectedDate) {
+                    setDate(selectedDate);
+                  }
+                }}
+                style={{ height: 200 }}
+              />
+            </View>
+          </View>
+        </Modal>
       )}
 
       {hasChanges ? (

--- a/src/screens/EditExpenseScreen.tsx
+++ b/src/screens/EditExpenseScreen.tsx
@@ -155,6 +155,7 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
   };
 
   const handleDateChange = (event: any, selectedDate?: Date) => {
+    console.log('DateTimePicker onChange called', event, selectedDate);
     setShowDatePicker(false);
     if (selectedDate) {
       setDate(selectedDate);
@@ -223,7 +224,10 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
 
       <Text style={{ fontSize: 18, fontWeight: '600', marginBottom: 8, color: textPrimary }}>Date</Text>
       <TouchableOpacity
-        onPress={() => setShowDatePicker(true)}
+        onPress={() => {
+          console.log('Date button pressed, setting showDatePicker to true');
+          setShowDatePicker(true);
+        }}
         style={{
           borderWidth: 1,
           padding: 12,
@@ -241,12 +245,22 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
       </TouchableOpacity>
 
       {showDatePicker && (
-        <DateTimePicker
-          value={date}
-          mode="date"
-          display="default"
-          onChange={handleDateChange}
-        />
+        <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.3)' }}>
+          <View style={{ backgroundColor: surfaceColor, padding: 20, borderRadius: 12 }}>
+            <DateTimePicker
+              value={date}
+              mode="date"
+              display="spinner"
+              onChange={handleDateChange}
+            />
+            <TouchableOpacity 
+              onPress={() => setShowDatePicker(false)}
+              style={{ padding: 10, alignItems: 'center' }}
+            >
+              <Text style={{ color: textPrimary, fontSize: 16 }}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
       )}
 
       {hasChanges ? (

--- a/src/screens/EditExpenseScreen.tsx
+++ b/src/screens/EditExpenseScreen.tsx
@@ -245,21 +245,14 @@ export default function EditExpenseScreen({ navigation, colorScheme, route }: Ed
       </TouchableOpacity>
 
       {showDatePicker && (
-        <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, justifyContent: 'center', alignItems: 'center', backgroundColor: 'rgba(0,0,0,0.3)' }}>
-          <View style={{ backgroundColor: surfaceColor, padding: 20, borderRadius: 12 }}>
-            <DateTimePicker
-              value={date}
-              mode="date"
-              display="spinner"
-              onChange={handleDateChange}
-            />
-            <TouchableOpacity 
-              onPress={() => setShowDatePicker(false)}
-              style={{ padding: 10, alignItems: 'center' }}
-            >
-              <Text style={{ color: textPrimary, fontSize: 16 }}>Cancel</Text>
-            </TouchableOpacity>
-          </View>
+        <View style={{ marginBottom: 20 }}>
+          <DateTimePicker
+            value={date}
+            mode="date"
+            display="spinner"
+            onChange={handleDateChange}
+            themeVariant={isDark ? 'dark' : 'light'}
+          />
         </View>
       )}
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import { Text, View, FlatList, ColorSchemeName } from 'react-native';
+import { Text, View, SectionList, ColorSchemeName } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { useExpenseStore } from '../features/expense/hooks/useExpenseStore';
 import { useTotalSpending } from '../features/expense/hooks/useTotalSpending';
@@ -8,6 +8,12 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { RootStackParamList } from '../navigation/AppNavigator';
 import { AnimatedExpenseItem } from '../components/AnimatedExpenseItem';
 import { FloatingActionButton } from '../components/FloatingActionButton';
+import type { Expense } from '../features/expense/types';
+
+type SectionData = {
+  title: string;
+  data: Expense[];
+};
 
 type HomeScreenProps = {
   navigation: NativeStackNavigationProp<RootStackParamList, 'Home'>;
@@ -26,6 +32,52 @@ export default function HomeScreen({ navigation, colorScheme }: HomeScreenProps)
   const textMuted = isDark ? COLORS.dark.text.muted : COLORS.text.muted;
   const borderColor = isDark ? COLORS.dark.border : COLORS.border;
 
+  const getSectionTitle = (dateString: string): string => {
+    const date = new Date(dateString);
+    const today = new Date();
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    if (date.toDateString() === today.toDateString()) return 'Today';
+    if (date.toDateString() === yesterday.toDateString()) return 'Yesterday';
+    return date.toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric' });
+  };
+
+  const groupedExpenses = expenses.reduce((sections: SectionData[], expense) => {
+    const title = getSectionTitle(expense.date);
+    const existingSection = sections.find(section => section.title === title);
+    
+    if (existingSection) {
+      existingSection.data.push(expense);
+    } else {
+      sections.push({ title, data: [expense] });
+    }
+    
+    return sections;
+  }, []);
+
+  groupedExpenses.forEach(section => {
+    section.data.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+  });
+
+  groupedExpenses.sort((a, b) => {
+    const dateA = new Date(a.data[0].date).getTime();
+    const dateB = new Date(b.data[0].date).getTime();
+    return dateB - dateA;
+  });
+
+  const renderSectionHeader = ({ section }: { section: SectionData }) => (
+    <Text style={{ 
+      fontSize: 14, 
+      fontWeight: '600', 
+      color: textSecondary, 
+      marginTop: 16, 
+      marginBottom: 8 
+    }}>
+      {section.title}
+    </Text>
+  );
+
   return (
     <View style={{ flex: 1, padding: 16, backgroundColor }}>
       <View style={{ backgroundColor: surfaceColor, padding: 16, marginBottom: 16, borderRadius: 12, borderWidth: 1, borderColor }}>
@@ -38,8 +90,8 @@ export default function HomeScreen({ navigation, colorScheme }: HomeScreenProps)
       {expenses.length === 0 ? (
         <Text style={{ textAlign: 'center', marginTop: 16, color: textMuted }}>No expenses yet</Text>
       ) : (
-        <FlatList
-          data={expenses}
+        <SectionList
+          sections={groupedExpenses}
           keyExtractor={(item) => item.id}
           renderItem={({ item, index }) => (
             <AnimatedExpenseItem 
@@ -49,7 +101,9 @@ export default function HomeScreen({ navigation, colorScheme }: HomeScreenProps)
               onPress={() => navigation.navigate('EditExpense', { expenseId: item.id })}
             />
           )}
+          renderSectionHeader={renderSectionHeader}
           style={{ marginTop: 16 }}
+          stickySectionHeadersEnabled={false}
         />
       )}
 


### PR DESCRIPTION
## Summary
Add manual date selection for expenses and group expenses by date on Home screen.

## Changes
- Added `@react-native-community/datetimepicker` for date selection
- Added date picker to AddExpenseScreen with "Today", "Yesterday", or full date display
- Added date picker to EditExpenseScreen for editing expense date
- Updated `useAddExpense` hook to include date state
- Replaced FlatList with SectionList in HomeScreen for grouped display
- Expenses grouped by: "Today", "Yesterday", or "April 7, 2026" format
- Expenses sorted within groups chronologically (newest first)

## Features
- Manual date entry for both add and edit screens
- Date picker with native OS UI
- Section list with sticky section headers disabled
- Dark mode support for date picker